### PR TITLE
Add Vesper theme

### DIFF
--- a/themes/README.md
+++ b/themes/README.md
@@ -40,7 +40,7 @@ Use `?theme=THEME_NAME` parameter like so:
 | `rose_pine` ![rose_pine][rose_pine] | `catppuccin_latte` ![catppuccin_latte][catppuccin_latte] | `catppuccin_mocha` ![catppuccin_mocha][catppuccin_mocha] |
 | `date_night` ![date_night][date_night] | `one_dark_pro` ![one_dark_pro][one_dark_pro] | `rose` ![rose][rose] |
 | `holi` ![holi][holi] | `neon` ![neon][neon] | `blue_navy` ![blue_navy][blue_navy] |
-| `calm_pink` ![calm_pink][calm_pink] | `ambient_gradient` ![ambient_gradient][ambient_gradient] |  |
+| `calm_pink` ![calm_pink][calm_pink] | `ambient_gradient` ![ambient_gradient][ambient_gradient] | `vesper` ![vesper][vesper] |
 
 ## Repo Card
 
@@ -72,7 +72,7 @@ Use `?theme=THEME_NAME` parameter like so:
 | `rose_pine` ![rose_pine][rose_pine_repo] | `catppuccin_latte` ![catppuccin_latte][catppuccin_latte_repo] | `catppuccin_mocha` ![catppuccin_mocha][catppuccin_mocha_repo] |
 | `date_night` ![date_night][date_night_repo] | `one_dark_pro` ![one_dark_pro][one_dark_pro_repo] | `rose` ![rose][rose_repo] |
 | `holi` ![holi][holi_repo] | `neon` ![neon][neon_repo] | `blue_navy` ![blue_navy][blue_navy_repo] |
-| `calm_pink` ![calm_pink][calm_pink_repo] | `ambient_gradient` ![ambient_gradient][ambient_gradient_repo] |  |
+| `calm_pink` ![calm_pink][calm_pink_repo] | `ambient_gradient` ![ambient_gradient][ambient_gradient_repo] | `vesper` ![vesper][vesper_repo] |
 
 
 [default]: https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true&hide=contribs,prs&cache_seconds=86400&theme=default
@@ -150,6 +150,7 @@ Use `?theme=THEME_NAME` parameter like so:
 [blue_navy]: https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true&hide=contribs,prs&cache_seconds=86400&theme=blue_navy
 [calm_pink]: https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true&hide=contribs,prs&cache_seconds=86400&theme=calm_pink
 [ambient_gradient]: https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true&hide=contribs,prs&cache_seconds=86400&theme=ambient_gradient
+[vesper]: https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true&hide=contribs,prs&cache_seconds=86400&theme=vesper
 
 
 [default_repo]: https://github-readme-stats.vercel.app/api/pin/?username=anuraghazra&repo=github-readme-stats&cache_seconds=86400&theme=default
@@ -227,3 +228,4 @@ Use `?theme=THEME_NAME` parameter like so:
 [blue_navy_repo]: https://github-readme-stats.vercel.app/api/pin/?username=anuraghazra&repo=github-readme-stats&cache_seconds=86400&theme=blue_navy
 [calm_pink_repo]: https://github-readme-stats.vercel.app/api/pin/?username=anuraghazra&repo=github-readme-stats&cache_seconds=86400&theme=calm_pink
 [ambient_gradient_repo]: https://github-readme-stats.vercel.app/api/pin/?username=anuraghazra&repo=github-readme-stats&cache_seconds=86400&theme=ambient_gradient
+[vesper_repo]: https://github-readme-stats.vercel.app/api/pin/?username=anuraghazra&repo=github-readme-stats&cache_seconds=86400&theme=vesper

--- a/themes/index.js
+++ b/themes/index.js
@@ -462,6 +462,12 @@ export const themes = {
     icon_color: "ffffff",
     bg_color: "35,4158d0,c850c0,ffcc70",
   },
+  vesper: {
+    title_color: "ffc799",
+    icon_color: "99ffe4",
+    text_color: "a0a0a0",
+    bg_color: "101010",
+  },
 };
 
 export default themes;


### PR DESCRIPTION
This pull request adds a new theme called `vesper` to the available themes for GitHub Readme Stats. The changes update the documentation and theme configuration to include the new theme.

Theme addition:

* Added a new `vesper` theme to the `themes/index.js` file with specified `title_color`, `icon_color`, `text_color`, and `bg_color`.

Documentation updates:

* Updated `themes/README.md` to include `vesper` in the list of available themes for both user and repo cards. [[1]](diffhunk://#diff-fa4c48189927314be9e14b264e8658eafa514abacf55eb31a5bf7abd746666e0L43-R43) [[2]](diffhunk://#diff-fa4c48189927314be9e14b264e8658eafa514abacf55eb31a5bf7abd746666e0L75-R75)
* Added links and image references for the new `vesper` theme and repo card in the documentation. [[1]](diffhunk://#diff-fa4c48189927314be9e14b264e8658eafa514abacf55eb31a5bf7abd746666e0R153) [[2]](diffhunk://#diff-fa4c48189927314be9e14b264e8658eafa514abacf55eb31a5bf7abd746666e0R231)